### PR TITLE
Fix broken CuffCompare link in README

### DIFF
--- a/README
+++ b/README
@@ -46,7 +46,7 @@ The full manual may be found at http://cufflinks.cbcb.umd.edu
 
 CUFFCOMPARE
 ----------------------------
-Please see http://cufflinks.cbcb.umd.edu/manual.html
+Please see http://cole-trapnell-lab.github.io/cufflinks/manual
 
 REQUIREMENTS
 ---------------------------


### PR DESCRIPTION
http://cole-trapnell-lab.github.io instead of http://cufflinks.cbcb.umd.edu

Maybe you want to update all links?