### PR TITLE
Follow PEP 0394 and use Python2 explicitly

### DIFF
--- a/src/cuffdiff_to_gct.py
+++ b/src/cuffdiff_to_gct.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 """
 cuffdiff_to_gct.py

--- a/src/cuffmerge
+++ b/src/cuffmerge
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 """
 cuffmerge.py


### PR DESCRIPTION
One system I'm using has both Python 2.7 and 3.4 installed. Invoking of `python` without any version specification starts version 3.4, despite the recommendation of [PEP 0394](https://www.python.org/dev/peps/pep-0394/). On this system, cuffmerge crashes with a syntax error.

PEP 0394 also recommends that scripts that are not compatible with both Python 2 and 3 specify which version of Python should be used:

> *In order to tolerate differences across platforms, all new code that needs to invoke the Python interpreter should not specify `python`, but rather should specify either `python2` or `python3` [...]

This push request specifies `python2` in the shebang of the two scripts using python I could find, namely `cuffmerge` and `cuffdiff_to_gct.py`.

All the systems I have ever seen have `python2` as a symbolic link to `python 2.X`. However this might not be universally true so you may want to consider this pull request carefully.
