### PR TITLE
change mkpath using boost::filesystem to avoid permission error in the parent folder

### DIFF
--- a/ax_boost_filesystem.m4
+++ b/ax_boost_filesystem.m4
@@ -1,0 +1,120 @@
+
+# ===========================================================================
+#   https://www.gnu.org/software/autoconf-archive/ax_boost_filesystem.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_FILESYSTEM
+#
+# DESCRIPTION
+#
+#   Test for Filesystem library from the Boost C++ libraries. The macro
+#   requires a preceding call to AX_BOOST_BASE. Further documentation is
+#   available at <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_FILESYSTEM_LIB)
+#
+#   And sets:
+#
+#     HAVE_BOOST_FILESYSTEM
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Michael Tindal
+#   Copyright (c) 2009 Roman Rybalko <libtorrent@romanr.info>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 27
+
+AC_DEFUN([AX_BOOST_FILESYSTEM],
+[
+    AC_ARG_WITH([boost-filesystem],
+    AS_HELP_STRING([--with-boost-filesystem@<:@=special-lib@:>@],
+                   [use the Filesystem library from boost - it is possible to specify a certain library for the linker
+                        e.g. --with-boost-filesystem=boost_filesystem-gcc-mt ]),
+        [
+        if test "$withval" = "no"; then
+            want_boost="no"
+        elif test "$withval" = "yes"; then
+            want_boost="yes"
+            ax_boost_user_filesystem_lib=""
+        else
+            want_boost="yes"
+        ax_boost_user_filesystem_lib="$withval"
+        fi
+        ],
+        [want_boost="yes"]
+    )
+
+    if test "x$want_boost" = "xyes"; then
+        AC_REQUIRE([AC_PROG_CC])
+        CPPFLAGS_SAVED="$CPPFLAGS"
+        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+        export CPPFLAGS
+
+        LDFLAGS_SAVED="$LDFLAGS"
+        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+        export LDFLAGS
+
+        LIBS_SAVED=$LIBS
+        LIBS="$LIBS $BOOST_SYSTEM_LIB"
+        export LIBS
+
+        AC_CACHE_CHECK(whether the Boost::Filesystem library is available,
+                       ax_cv_boost_filesystem,
+        [AC_LANG_PUSH([C++])
+         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/filesystem/path.hpp>]],
+                                   [[using namespace boost::filesystem;
+                                   path my_path( "foo/bar/data.txt" );
+                                   return 0;]])],
+                           ax_cv_boost_filesystem=yes, ax_cv_boost_filesystem=no)
+         AC_LANG_POP([C++])
+        ])
+        if test "x$ax_cv_boost_filesystem" = "xyes"; then
+            AC_DEFINE(HAVE_BOOST_FILESYSTEM,,[define if the Boost::Filesystem library is available])
+            BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+            if test "x$ax_boost_user_filesystem_lib" = "x"; then
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_filesystem* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
+                     ax_lib=${libextension}
+                    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],
+                                 [link_filesystem="no"])
+                done
+                if test "x$link_filesystem" != "xyes"; then
+                for libextension in `ls -r $BOOSTLIBDIR/boost_filesystem* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
+                     ax_lib=${libextension}
+                    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],
+                                 [link_filesystem="no"])
+                done
+            fi
+            else
+               for ax_lib in $ax_boost_user_filesystem_lib boost_filesystem-$ax_boost_user_filesystem_lib; do
+                      AC_CHECK_LIB($ax_lib, exit,
+                                   [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],
+                                   [link_filesystem="no"])
+                  done
+
+            fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+            if test "x$link_filesystem" != "xyes"; then
+                AC_MSG_ERROR(Could not link against $ax_lib !)
+            fi
+        fi
+
+        CPPFLAGS="$CPPFLAGS_SAVED"
+        LDFLAGS="$LDFLAGS_SAVED"
+        LIBS="$LIBS_SAVED"
+    fi
+])
+

--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ m4_include([ax_boost_base.m4])
 m4_include([ax_boost_thread.m4])
 m4_include([ax_boost_system.m4])
 m4_include([ax_boost_serialization.m4])
+m4_include([ax_boost_filesystem.m4])
 m4_include([ax_bam.m4])
 m4_include([ax_check_zlib.m4])
 
@@ -37,6 +38,7 @@ AX_BOOST_BASE([1.47.0])
 AX_BAM
 AX_BOOST_SYSTEM
 AX_BOOST_SERIALIZATION
+AX_BOOST_FILESYSTEM
 AX_BOOST_THREAD
 AX_CHECK_ZLIB()
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -206,7 +206,7 @@ CLEANFILES = $(bin_SCRIPTS)
 #	(echo '#!$(PYTHON)'; sed '/^#!/d' $<) > $@
 
 cufflinks_SOURCES = cufflinks.cpp  
-cufflinks_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB)  $(BOOST_SERIALIZATION_LIB)  $(BAM_LIB) 
+cufflinks_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB)  $(BOOST_SERIALIZATION_LIB) $(BOOST_FILESYSTEM_LIB)  $(BAM_LIB) 
 cufflinks_LDFLAGS =  $(LDFLAGS) $(BOOST_LDFLAGS) $(BAM_LDFLAGS) #$(ZLIB_LDFLAGS) 
 
 cuffcompare_SOURCES = cuffcompare.cpp
@@ -216,30 +216,30 @@ gffread_SOURCES = gffread.cpp
 gffread_LDADD = libgc.a
 
 cuffdiff_SOURCES = cuffdiff.cpp
-cuffdiff_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BAM_LIB)
+cuffdiff_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_FILESYSTEM_LIB) $(BAM_LIB)
 cuffdiff_LDFLAGS =  $(LDFLAGS) $(BOOST_LDFLAGS) $(BAM_LDFLAGS) 
 
 cuffquant_SOURCES = cuffquant.cpp
-cuffquant_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BAM_LIB)
+cuffquant_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_FILESYSTEM_LIB) $(BAM_LIB)
 cuffquant_LDFLAGS =  $(LDFLAGS) $(BOOST_LDFLAGS) $(BAM_LDFLAGS) 
 
 cuffnorm_SOURCES = cuffnorm.cpp
-cuffnorm_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BAM_LIB)
+cuffnorm_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_FILESYSTEM_LIB) $(BAM_LIB)
 cuffnorm_LDFLAGS =  $(LDFLAGS) $(BOOST_LDFLAGS) $(BAM_LDFLAGS)
 
 
 gtf_to_sam_SOURCES = gtf_to_sam.cpp
-gtf_to_sam_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BAM_LIB)
+gtf_to_sam_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_FILESYSTEM_LIB) $(BAM_LIB)
 gtf_to_sam_LDFLAGS =  $(LDFLAGS) $(BOOST_LDFLAGS) $(BAM_LDFLAGS) 
 
 #cuffcluster_SOURCES = cuffcluster.cpp
-#cuffcluster_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BAM_LIB)
+#cuffcluster_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_FILESYSTEM_LIB) $(BAM_LIB)
 #cuffcluster_LDFLAGS =  $(LDFLAGS) $(BOOST_LDFLAGS) $(BAM_LDFLAGS) 
 
 compress_gtf_SOURCES = compress_gtf.cpp
-compress_gtf_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BAM_LIB)
+compress_gtf_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_FILESYSTEM_LIB) $(BAM_LIB)
 compress_gtf_LDFLAGS =  $(LDFLAGS) $(BOOST_LDFLAGS) $(BAM_LDFLAGS) 
 
 #gtf_reads_SOURCES = gtf_reads.cpp
-#gtf_reads_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BAM_LIB) 
+#gtf_reads_LDADD = libcufflinks.a libgc.a $(BOOST_THREAD_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_FILESYSTEM_LIB) $(BAM_LIB) 
 #gtf_reads_LDFLAGS =  $(LDFLAGS) $(BOOST_LDFLAGS) $(BAM_LDFLAGS) #$(ZLIB_LDFLAGS)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -257,43 +257,30 @@ float parseFloat(float lower, float upper, const char *errmsg, void (*print_usag
 }
 
 /* Function with behaviour like `mkdir -p'  */
-/* found at: http://niallohiggins.com/2009/01/08/mkpath-mkdir-p-alike-in-c-for-unix/ */
 
 int mkpath(const char *s, mode_t mode)
 {
-    char *q, *r = NULL, *path = NULL, *up = NULL;
-    int rv;
-    
-    rv = -1;
-    if (strcmp(s, ".") == 0 || strcmp(s, "/") == 0)
-        return (0);
-    
-    if ((path = strdup(s)) == NULL)
-        exit(1);
-    
-    if ((q = strdup(s)) == NULL)
-        exit(1);
-    
-    if ((r = dirname(q)) == NULL)
-        goto out;
-    
-    if ((up = strdup(r)) == NULL)
-        exit(1);
-    
-    if ((mkpath(up, mode) == -1) && (errno != EEXIST))
-        goto out;
-    
-    if ((mkdir(path, mode) == -1) && (errno != EEXIST))
-        rv = -1;
-    else
-        rv = 0;
-    
-out:
-    if (up != NULL)
-        free(up);
-    free(q);
-    free(path);
-    return (rv);
+    namespace fs = boost::filesystem;
+    namespace bs = boost::system;
+
+    // First try create the directory
+    try {
+        fs::create_directories(s);
+        try {
+            // Then make sure it is writable
+            fs::permissions(s, fs::owner_all | fs::add_perms);
+            errno = 0;
+            // Otherwise, exit
+        } catch (const fs::filesystem_error & ep) {
+            std::cerr << ep.what() << '\n';
+            exit(-1);
+        }
+    } catch (const fs::filesystem_error & e) {
+        std::cerr << e.what() << '\n';
+        exit(-1);
+    }
+
+    return 0;
 }
 
 void init_library_table()

--- a/src/common.h
+++ b/src/common.h
@@ -49,6 +49,8 @@ using boost::math::normal;
 
 #include <boost/crc.hpp>
 
+#include <boost/filesystem.hpp>
+
 // Non-option globals
 extern bool final_est_run;
 extern bool allow_junk_filtering;


### PR DESCRIPTION
Firstly, we greatly thank the author for this wonderful code. 

When using '-o' command line argument to specify output directory, it seems that the original version always tries to create all parent folders recursively with 777 permission. For example, '-o /home/user/output' will at some point try to create '/home' with 777 permission. This will raise 2 system errors: 1. Directory exists. 2. Permission denied. The first error is handled (for example, in cufflinks.cpp) but the second is not. Even if a user has permission to create '/home/user/output', if the system return 'permission denied' error code when trying to create '/home', the code will stop.

This patch changed the 'mkpath' function in common.cpp using boost::filesystem libraries. Permission and folder creations are properly handled.