### PR TITLE
fix github repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cd cufflinks-2.2.1
 
 ### If you want to clone the Cufflinks github repo:
 ```bash
-git clone git@github.com:cole-trapnell-lab/cufflinks.git
+git clone https://github.com/cole-trapnell-lab/cufflinks.git
 cd cufflinks
 autoreconf --install
 ```


### PR DESCRIPTION
Use HTTPS and not SSH URL since this is what most people need to use to clone repo; unless they're a direct contributor.