### PR TITLE
Fix building cufflinks with GCC-6

### DIFF
--- a/src/lemon/error.h
+++ b/src/lemon/error.h
@@ -67,9 +67,9 @@ namespace lemon {
     }
 
     ExceptionMember& operator=(const ExceptionMember& copy) {
-      if (ptr.get() == 0) return;
+      if (ptr.get() == 0) return *this;
       try {
-	if (!copy.valid()) return;
+	if (!copy.valid()) return *this;
  	*ptr = copy.get();
       } catch (...) {}
     }


### PR DESCRIPTION
Building with GCC-6.3.0 fails with:

```
./lemon/error.h:70:27: error: return-statement with no value, in function returning ‘lemon::ExceptionMember<_Type>&’ [-fpermissive]
       if (ptr.get() == 0) return;
                           ^~~~~~
./lemon/error.h:72:21: error: return-statement with no value, in function returning ‘lemon::ExceptionMember<_Type>&’ [-fpermissive]
  if (!copy.valid()) return;
                     ^~~~~~
```

Other versions may have implicitly returned `*this` instead of `void` but `void` return in a function not returning `void` is no longer accepted.