### PR TITLE
Fix build on Ubuntu 19.04

### DIFF
--- a/ax_boost_base.m4
+++ b/ax_boost_base.m4
@@ -1,10 +1,10 @@
 # ===========================================================================
-#             http://autoconf-archive.cryp.to/ax_boost_base.html
+#      https://www.gnu.org/software/autoconf-archive/ax_boost_base.html
 # ===========================================================================
 #
 # SYNOPSIS
 #
-#   AX_BOOST_BASE([MINIMUM-VERSION])
+#   AX_BOOST_BASE([MINIMUM-VERSION], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
 #
 # DESCRIPTION
 #
@@ -26,194 +26,276 @@
 # LICENSE
 #
 #   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Peter Adolphs
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
-#   and this notice are preserved.
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 45
+
+# example boost program (need to pass version)
+m4_define([_AX_BOOST_BASE_PROGRAM],
+          [AC_LANG_PROGRAM([[
+#include <boost/version.hpp>
+]],[[
+(void) ((void)sizeof(char[1 - 2*!!((BOOST_VERSION) < ($1))]));
+]])])
 
 AC_DEFUN([AX_BOOST_BASE],
 [
 AC_ARG_WITH([boost],
-	AS_HELP_STRING([--with-boost@<:@=DIR@:>@], [use boost (default is yes) - it is possible to specify the root directory for boost (optional)]),
-	[
-    if test "$withval" = "no"; then
-		want_boost="no"
-    elif test "$withval" = "yes"; then
-        want_boost="yes"
-        ac_boost_path=""
-    else
-	    want_boost="yes"
-        ac_boost_path="$withval"
-	fi
+  [AS_HELP_STRING([--with-boost@<:@=ARG@:>@],
+    [use Boost library from a standard location (ARG=yes),
+     from the specified location (ARG=<path>),
+     or disable it (ARG=no)
+     @<:@ARG=yes@:>@ ])],
+    [
+     AS_CASE([$withval],
+       [no],[want_boost="no";_AX_BOOST_BASE_boost_path=""],
+       [yes],[want_boost="yes";_AX_BOOST_BASE_boost_path=""],
+       [want_boost="yes";_AX_BOOST_BASE_boost_path="$withval"])
     ],
     [want_boost="yes"])
 
 
 AC_ARG_WITH([boost-libdir],
-        AS_HELP_STRING([--with-boost-libdir=LIB_DIR],
-        [Force given directory for boost libraries. Note that this will overwrite library path detection, so use this parameter only if default library detection fails and you know exactly where your boost libraries are located.]),
-        [
-        if test -d $withval
-        then
-                ac_boost_lib_path="$withval"
+  [AS_HELP_STRING([--with-boost-libdir=LIB_DIR],
+    [Force given directory for boost libraries.
+     Note that this will override library path detection,
+     so use this parameter only if default library detection fails
+     and you know exactly where your boost libraries are located.])],
+  [
+   AS_IF([test -d "$withval"],
+         [_AX_BOOST_BASE_boost_lib_path="$withval"],
+    [AC_MSG_ERROR([--with-boost-libdir expected directory name])])
+  ],
+  [_AX_BOOST_BASE_boost_lib_path=""])
+
+BOOST_LDFLAGS=""
+BOOST_CPPFLAGS=""
+AS_IF([test "x$want_boost" = "xyes"],
+      [_AX_BOOST_BASE_RUNDETECT([$1],[$2],[$3])])
+AC_SUBST(BOOST_CPPFLAGS)
+AC_SUBST(BOOST_LDFLAGS)
+])
+
+
+# convert a version string in $2 to numeric and affect to polymorphic var $1
+AC_DEFUN([_AX_BOOST_BASE_TONUMERICVERSION],[
+  AS_IF([test "x$2" = "x"],[_AX_BOOST_BASE_TONUMERICVERSION_req="1.20.0"],[_AX_BOOST_BASE_TONUMERICVERSION_req="$2"])
+  _AX_BOOST_BASE_TONUMERICVERSION_req_shorten=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([[0-9]]*\.[[0-9]]*\)'`
+  _AX_BOOST_BASE_TONUMERICVERSION_req_major=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([[0-9]]*\)'`
+  AS_IF([test "x$_AX_BOOST_BASE_TONUMERICVERSION_req_major" = "x"],
+        [AC_MSG_ERROR([You should at least specify libboost major version])])
+  _AX_BOOST_BASE_TONUMERICVERSION_req_minor=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '[[0-9]]*\.\([[0-9]]*\)'`
+  AS_IF([test "x$_AX_BOOST_BASE_TONUMERICVERSION_req_minor" = "x"],
+        [_AX_BOOST_BASE_TONUMERICVERSION_req_minor="0"])
+  _AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
+  AS_IF([test "X$_AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor" = "X"],
+        [_AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor="0"])
+  _AX_BOOST_BASE_TONUMERICVERSION_RET=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req_major \* 100000 \+  $_AX_BOOST_BASE_TONUMERICVERSION_req_minor \* 100 \+ $_AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor`
+  AS_VAR_SET($1,$_AX_BOOST_BASE_TONUMERICVERSION_RET)
+])
+
+dnl Run the detection of boost should be run only if $want_boost
+AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
+    _AX_BOOST_BASE_TONUMERICVERSION(WANT_BOOST_VERSION,[$1])
+    succeeded=no
+
+
+    AC_REQUIRE([AC_CANONICAL_HOST])
+    dnl On 64-bit systems check for system libraries in both lib64 and lib.
+    dnl The former is specified by FHS, but e.g. Debian does not adhere to
+    dnl this (as it rises problems for generic multi-arch support).
+    dnl The last entry in the list is chosen by default when no libraries
+    dnl are found, e.g. when only header-only libraries are installed!
+    AS_CASE([${host_cpu}],
+      [x86_64],[libsubdirs="lib64 libx32 lib lib64"],
+      [ppc64|powerpc64|s390x|sparc64|aarch64|ppc64le|powerpc64le|riscv64],[libsubdirs="lib64 lib lib64"],
+      [libsubdirs="lib"]
+    )
+
+    dnl allow for real multi-arch paths e.g. /usr/lib/x86_64-linux-gnu. Give
+    dnl them priority over the other paths since, if libs are found there, they
+    dnl are almost assuredly the ones desired.
+    AS_CASE([${host_cpu}],
+      [i?86],[multiarch_libsubdir="lib/i386-${host_os}"],
+      [multiarch_libsubdir="lib/${host_cpu}-${host_os}"]
+    )
+
+    dnl first we check the system location for boost libraries
+    dnl this location ist chosen if boost libraries are installed with the --layout=system option
+    dnl or if you install boost with RPM
+    AS_IF([test "x$_AX_BOOST_BASE_boost_path" != "x"],[
+        AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION) includes in "$_AX_BOOST_BASE_boost_path/include"])
+         AS_IF([test -d "$_AX_BOOST_BASE_boost_path/include" && test -r "$_AX_BOOST_BASE_boost_path/include"],[
+           AC_MSG_RESULT([yes])
+           BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path/include"
+           for _AX_BOOST_BASE_boost_path_tmp in $multiarch_libsubdir $libsubdirs; do
+                AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION) lib path in "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp"])
+                AS_IF([test -d "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp" && test -r "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp" ],[
+                        AC_MSG_RESULT([yes])
+                        BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp";
+                        break;
+                ],
+      [AC_MSG_RESULT([no])])
+           done],[
+      AC_MSG_RESULT([no])])
+    ],[
+        if test X"$cross_compiling" = Xyes; then
+            search_libsubdirs=$multiarch_libsubdir
         else
-                AC_MSG_ERROR(--with-boost-libdir expected directory name)
+            search_libsubdirs="$multiarch_libsubdir $libsubdirs"
         fi
-        ],
-        [ac_boost_lib_path=""]
-)
-
-if test "x$want_boost" = "xyes"; then
-	boost_lib_version_req=ifelse([$1], ,1.20.0,$1)
-	boost_lib_version_req_shorten=`expr $boost_lib_version_req : '\([[0-9]]*\.[[0-9]]*\)'`
-	boost_lib_version_req_major=`expr $boost_lib_version_req : '\([[0-9]]*\)'`
-	boost_lib_version_req_minor=`expr $boost_lib_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
-	boost_lib_version_req_sub_minor=`expr $boost_lib_version_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
-	if test "x$boost_lib_version_req_sub_minor" = "x" ; then
-		boost_lib_version_req_sub_minor="0"
-    	fi
-	WANT_BOOST_VERSION=`expr $boost_lib_version_req_major \* 100000 \+  $boost_lib_version_req_minor \* 100 \+ $boost_lib_version_req_sub_minor`
-	AC_MSG_CHECKING(for boostlib >= $boost_lib_version_req)
-	succeeded=no
-
-	dnl first we check the system location for boost libraries
-	dnl this location ist chosen if boost libraries are installed with the --layout=system option
-	dnl or if you install boost with RPM
-	if test "$ac_boost_path" != ""; then
-		BOOST_LDFLAGS="-L$ac_boost_path/lib"
-		BOOST_CPPFLAGS="-I$ac_boost_path/include"
-	else
-		for ac_boost_path_tmp in /usr /usr/local /opt /opt/local ; do
-			if test -d "$ac_boost_path_tmp/include/boost" && test -r "$ac_boost_path_tmp/include/boost"; then
-				BOOST_LDFLAGS="-L$ac_boost_path_tmp/lib"
-				BOOST_CPPFLAGS="-I$ac_boost_path_tmp/include"
-				break;
-			fi
-		done
-	fi
+        for _AX_BOOST_BASE_boost_path_tmp in /usr /usr/local /opt /opt/local ; do
+            if test -d "$_AX_BOOST_BASE_boost_path_tmp/include/boost" && test -r "$_AX_BOOST_BASE_boost_path_tmp/include/boost" ; then
+                for libsubdir in $search_libsubdirs ; do
+                    if ls "$_AX_BOOST_BASE_boost_path_tmp/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                done
+                BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_path_tmp/$libsubdir"
+                BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path_tmp/include"
+                break;
+            fi
+        done
+    ])
 
     dnl overwrite ld flags if we have required special directory with
     dnl --with-boost-libdir parameter
-    if test "$ac_boost_lib_path" != ""; then
-       BOOST_LDFLAGS="-L$ac_boost_lib_path"
-    fi
+    AS_IF([test "x$_AX_BOOST_BASE_boost_lib_path" != "x"],
+          [BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_lib_path"])
 
-	CPPFLAGS_SAVED="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-	export CPPFLAGS
+    AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION)])
+    CPPFLAGS_SAVED="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+    export CPPFLAGS
 
-	LDFLAGS_SAVED="$LDFLAGS"
-	LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
-	export LDFLAGS
+    LDFLAGS_SAVED="$LDFLAGS"
+    LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+    export LDFLAGS
 
-	AC_LANG_PUSH(C++)
-     	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-	@%:@include <boost/version.hpp>
-	]], [[
-	#if BOOST_VERSION >= $WANT_BOOST_VERSION
-	// Everything is okay
-	#else
-	#  error Boost version is too old
-	#endif
-	]])],[
+    AC_REQUIRE([AC_PROG_CXX])
+    AC_LANG_PUSH(C++)
+        AC_COMPILE_IFELSE([_AX_BOOST_BASE_PROGRAM($WANT_BOOST_VERSION)],[
         AC_MSG_RESULT(yes)
-	succeeded=yes
-	found_system=yes
-       	],[
-       	])
-	AC_LANG_POP([C++])
+    succeeded=yes
+    found_system=yes
+        ],[
+        ])
+    AC_LANG_POP([C++])
 
 
 
-	dnl if we found no boost with system layout we search for boost libraries
-	dnl built and installed without the --layout=system option or for a staged(not installed) version
-	if test "x$succeeded" != "xyes"; then
-		_version=0
-		if test "$ac_boost_path" != ""; then
-			if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
-				for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
-					_version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
-					V_CHECK=`expr $_version_tmp \> $_version`
-					if test "$V_CHECK" = "1" ; then
-						_version=$_version_tmp
-					fi
-					VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
-					BOOST_CPPFLAGS="-I$ac_boost_path/include/boost-$VERSION_UNDERSCORE"
-				done
-			fi
-		else
-			for ac_boost_path in /usr /usr/local /opt /opt/local ; do
-				if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
-					for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
-						_version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
-						V_CHECK=`expr $_version_tmp \> $_version`
-						if test "$V_CHECK" = "1" ; then
-							_version=$_version_tmp
-	               					best_path=$ac_boost_path
-						fi
-					done
-				fi
-			done
+    dnl if we found no boost with system layout we search for boost libraries
+    dnl built and installed without the --layout=system option or for a staged(not installed) version
+    if test "x$succeeded" != "xyes" ; then
+        CPPFLAGS="$CPPFLAGS_SAVED"
+        LDFLAGS="$LDFLAGS_SAVED"
+        BOOST_CPPFLAGS=
+        if test -z "$_AX_BOOST_BASE_boost_lib_path" ; then
+            BOOST_LDFLAGS=
+        fi
+        _version=0
+        if test -n "$_AX_BOOST_BASE_boost_path" ; then
+            if test -d "$_AX_BOOST_BASE_boost_path" && test -r "$_AX_BOOST_BASE_boost_path"; then
+                for i in `ls -d $_AX_BOOST_BASE_boost_path/include/boost-* 2>/dev/null`; do
+                    _version_tmp=`echo $i | sed "s#$_AX_BOOST_BASE_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+                    V_CHECK=`expr $_version_tmp \> $_version`
+                    if test "x$V_CHECK" = "x1" ; then
+                        _version=$_version_tmp
+                    fi
+                    VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
+                    BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path/include/boost-$VERSION_UNDERSCORE"
+                done
+                dnl if nothing found search for layout used in Windows distributions
+                if test -z "$BOOST_CPPFLAGS"; then
+                    if test -d "$_AX_BOOST_BASE_boost_path/boost" && test -r "$_AX_BOOST_BASE_boost_path/boost"; then
+                        BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path"
+                    fi
+                fi
+                dnl if we found something and BOOST_LDFLAGS was unset before
+                dnl (because "$_AX_BOOST_BASE_boost_lib_path" = ""), set it here.
+                if test -n "$BOOST_CPPFLAGS" && test -z "$BOOST_LDFLAGS"; then
+                    for libsubdir in $libsubdirs ; do
+                        if ls "$_AX_BOOST_BASE_boost_path/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                    done
+                    BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_path/$libsubdir"
+                fi
+            fi
+        else
+            if test "x$cross_compiling" != "xyes" ; then
+                for _AX_BOOST_BASE_boost_path in /usr /usr/local /opt /opt/local ; do
+                    if test -d "$_AX_BOOST_BASE_boost_path" && test -r "$_AX_BOOST_BASE_boost_path" ; then
+                        for i in `ls -d $_AX_BOOST_BASE_boost_path/include/boost-* 2>/dev/null`; do
+                            _version_tmp=`echo $i | sed "s#$_AX_BOOST_BASE_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+                            V_CHECK=`expr $_version_tmp \> $_version`
+                            if test "x$V_CHECK" = "x1" ; then
+                                _version=$_version_tmp
+                                best_path=$_AX_BOOST_BASE_boost_path
+                            fi
+                        done
+                    fi
+                done
 
-			VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
-			BOOST_CPPFLAGS="-I$best_path/include/boost-$VERSION_UNDERSCORE"
-            if test "$ac_boost_lib_path" = ""
-            then
-               BOOST_LDFLAGS="-L$best_path/lib"
+                VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
+                BOOST_CPPFLAGS="-I$best_path/include/boost-$VERSION_UNDERSCORE"
+                if test -z "$_AX_BOOST_BASE_boost_lib_path" ; then
+                    for libsubdir in $libsubdirs ; do
+                        if ls "$best_path/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                    done
+                    BOOST_LDFLAGS="-L$best_path/$libsubdir"
+                fi
             fi
 
-	    		if test "x$BOOST_ROOT" != "x"; then
-				if test -d "$BOOST_ROOT" && test -r "$BOOST_ROOT" && test -d "$BOOST_ROOT/stage/lib" && test -r "$BOOST_ROOT/stage/lib"; then
-					version_dir=`expr //$BOOST_ROOT : '.*/\(.*\)'`
-					stage_version=`echo $version_dir | sed 's/boost_//' | sed 's/_/./g'`
-			        	stage_version_shorten=`expr $stage_version : '\([[0-9]]*\.[[0-9]]*\)'`
-					V_CHECK=`expr $stage_version_shorten \>\= $_version`
-                    if test "$V_CHECK" = "1" -a "$ac_boost_lib_path" = "" ; then
-						AC_MSG_NOTICE(We will use a staged boost library from $BOOST_ROOT)
-						BOOST_CPPFLAGS="-I$BOOST_ROOT"
-						BOOST_LDFLAGS="-L$BOOST_ROOT/stage/lib"
-					fi
-				fi
-	    		fi
-		fi
+            if test -n "$BOOST_ROOT" ; then
+                for libsubdir in $libsubdirs ; do
+                    if ls "$BOOST_ROOT/stage/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                done
+                if test -d "$BOOST_ROOT" && test -r "$BOOST_ROOT" && test -d "$BOOST_ROOT/stage/$libsubdir" && test -r "$BOOST_ROOT/stage/$libsubdir"; then
+                    version_dir=`expr //$BOOST_ROOT : '.*/\(.*\)'`
+                    stage_version=`echo $version_dir | sed 's/boost_//' | sed 's/_/./g'`
+                        stage_version_shorten=`expr $stage_version : '\([[0-9]]*\.[[0-9]]*\)'`
+                    V_CHECK=`expr $stage_version_shorten \>\= $_version`
+                    if test "x$V_CHECK" = "x1" && test -z "$_AX_BOOST_BASE_boost_lib_path" ; then
+                        AC_MSG_NOTICE(We will use a staged boost library from $BOOST_ROOT)
+                        BOOST_CPPFLAGS="-I$BOOST_ROOT"
+                        BOOST_LDFLAGS="-L$BOOST_ROOT/stage/$libsubdir"
+                    fi
+                fi
+            fi
+        fi
 
-		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-		export CPPFLAGS
-		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
-		export LDFLAGS
+        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+        export CPPFLAGS
+        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+        export LDFLAGS
 
-		AC_LANG_PUSH(C++)
-	     	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-		@%:@include <boost/version.hpp>
-		]], [[
-		#if BOOST_VERSION >= $WANT_BOOST_VERSION
-		// Everything is okay
-		#else
-		#  error Boost version is too old
-		#endif
-		]])],[
-        	AC_MSG_RESULT(yes)
-		succeeded=yes
-		found_system=yes
-       		],[
-	       	])
-		AC_LANG_POP([C++])
-	fi
+        AC_LANG_PUSH(C++)
+            AC_COMPILE_IFELSE([_AX_BOOST_BASE_PROGRAM($WANT_BOOST_VERSION)],[
+            AC_MSG_RESULT(yes)
+        succeeded=yes
+        found_system=yes
+            ],[
+            ])
+        AC_LANG_POP([C++])
+    fi
 
-	if test "$succeeded" != "yes" ; then
-		if test "$_version" = "0" ; then
-			AC_MSG_ERROR([[We could not detect the boost libraries (version $boost_lib_version_req_shorten or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.]])
-		else
-			AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])
-		fi
-	else
-		AC_SUBST(BOOST_CPPFLAGS)
-		AC_SUBST(BOOST_LDFLAGS)
-		AC_DEFINE(HAVE_BOOST,,[define if the Boost library is available])
-	fi
+    if test "x$succeeded" != "xyes" ; then
+        if test "x$_version" = "x0" ; then
+            AC_MSG_NOTICE([[We could not detect the boost libraries (version $1 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.]])
+        else
+            AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])
+        fi
+        # execute ACTION-IF-NOT-FOUND (if present):
+        ifelse([$3], , :, [$3])
+    else
+        AC_DEFINE(HAVE_BOOST,,[define if the Boost library is available])
+        # execute ACTION-IF-FOUND (if present):
+        ifelse([$2], , :, [$2])
+    fi
 
-        CPPFLAGS="$CPPFLAGS_SAVED"
-       	LDFLAGS="$LDFLAGS_SAVED"
-fi
+    CPPFLAGS="$CPPFLAGS_SAVED"
+    LDFLAGS="$LDFLAGS_SAVED"
 
 ])

--- a/ax_boost_filesystem.m4
+++ b/ax_boost_filesystem.m4
@@ -1,4 +1,3 @@
-
 # ===========================================================================
 #   https://www.gnu.org/software/autoconf-archive/ax_boost_filesystem.html
 # ===========================================================================
@@ -36,69 +35,69 @@
 
 AC_DEFUN([AX_BOOST_FILESYSTEM],
 [
-    AC_ARG_WITH([boost-filesystem],
-    AS_HELP_STRING([--with-boost-filesystem@<:@=special-lib@:>@],
+	AC_ARG_WITH([boost-filesystem],
+	AS_HELP_STRING([--with-boost-filesystem@<:@=special-lib@:>@],
                    [use the Filesystem library from boost - it is possible to specify a certain library for the linker
                         e.g. --with-boost-filesystem=boost_filesystem-gcc-mt ]),
         [
         if test "$withval" = "no"; then
-            want_boost="no"
+			want_boost="no"
         elif test "$withval" = "yes"; then
             want_boost="yes"
             ax_boost_user_filesystem_lib=""
         else
-            want_boost="yes"
-        ax_boost_user_filesystem_lib="$withval"
-        fi
+		    want_boost="yes"
+		ax_boost_user_filesystem_lib="$withval"
+		fi
         ],
         [want_boost="yes"]
-    )
+	)
 
-    if test "x$want_boost" = "xyes"; then
+	if test "x$want_boost" = "xyes"; then
         AC_REQUIRE([AC_PROG_CC])
-        CPPFLAGS_SAVED="$CPPFLAGS"
-        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-        export CPPFLAGS
+		CPPFLAGS_SAVED="$CPPFLAGS"
+		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+		export CPPFLAGS
 
-        LDFLAGS_SAVED="$LDFLAGS"
-        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
-        export LDFLAGS
+		LDFLAGS_SAVED="$LDFLAGS"
+		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+		export LDFLAGS
 
-        LIBS_SAVED=$LIBS
-        LIBS="$LIBS $BOOST_SYSTEM_LIB"
-        export LIBS
+		LIBS_SAVED=$LIBS
+		LIBS="$LIBS $BOOST_SYSTEM_LIB"
+		export LIBS
 
         AC_CACHE_CHECK(whether the Boost::Filesystem library is available,
-                       ax_cv_boost_filesystem,
+					   ax_cv_boost_filesystem,
         [AC_LANG_PUSH([C++])
          AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/filesystem/path.hpp>]],
                                    [[using namespace boost::filesystem;
                                    path my_path( "foo/bar/data.txt" );
                                    return 0;]])],
-                           ax_cv_boost_filesystem=yes, ax_cv_boost_filesystem=no)
+					       ax_cv_boost_filesystem=yes, ax_cv_boost_filesystem=no)
          AC_LANG_POP([C++])
-        ])
-        if test "x$ax_cv_boost_filesystem" = "xyes"; then
-            AC_DEFINE(HAVE_BOOST_FILESYSTEM,,[define if the Boost::Filesystem library is available])
+		])
+		if test "x$ax_cv_boost_filesystem" = "xyes"; then
+			AC_DEFINE(HAVE_BOOST_FILESYSTEM,,[define if the Boost::Filesystem library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
             if test "x$ax_boost_user_filesystem_lib" = "x"; then
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_filesystem* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
-                    AC_CHECK_LIB($ax_lib, exit,
+				    AC_CHECK_LIB($ax_lib, main,
                                  [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],
                                  [link_filesystem="no"])
-                done
+				done
                 if test "x$link_filesystem" != "xyes"; then
                 for libextension in `ls -r $BOOSTLIBDIR/boost_filesystem* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
                      ax_lib=${libextension}
-                    AC_CHECK_LIB($ax_lib, exit,
+				    AC_CHECK_LIB($ax_lib, main,
                                  [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],
                                  [link_filesystem="no"])
-                done
-            fi
+				done
+		    fi
             else
                for ax_lib in $ax_boost_user_filesystem_lib boost_filesystem-$ax_boost_user_filesystem_lib; do
-                      AC_CHECK_LIB($ax_lib, exit,
+				      AC_CHECK_LIB($ax_lib, main,
                                    [BOOST_FILESYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_FILESYSTEM_LIB) link_filesystem="yes"; break],
                                    [link_filesystem="no"])
                   done
@@ -107,14 +106,13 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
             if test "x$ax_lib" = "x"; then
                 AC_MSG_ERROR(Could not find a version of the library!)
             fi
-            if test "x$link_filesystem" != "xyes"; then
-                AC_MSG_ERROR(Could not link against $ax_lib !)
-            fi
-        fi
+			if test "x$link_filesystem" != "xyes"; then
+				AC_MSG_ERROR(Could not link against $ax_lib !)
+			fi
+		fi
 
-        CPPFLAGS="$CPPFLAGS_SAVED"
-        LDFLAGS="$LDFLAGS_SAVED"
-        LIBS="$LIBS_SAVED"
-    fi
+		CPPFLAGS="$CPPFLAGS_SAVED"
+		LDFLAGS="$LDFLAGS_SAVED"
+		LIBS="$LIBS_SAVED"
+	fi
 ])
-

--- a/ax_boost_serialization.m4
+++ b/ax_boost_serialization.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#            http://autoconf-archive.cryp.to/ax_boost_serialization.html
+#  https://www.gnu.org/software/autoconf-archive/ax_boost_serialization.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -8,13 +8,12 @@
 #
 # DESCRIPTION
 #
-#   Test for Serialization library from the Boost C++ libraries. The macro requires
-#   a preceding call to AX_BOOST_BASE. Further documentation is available at
-#   <http://randspringer.de/boost/index.html>.
+#   Test for Serialization library from the Boost C++ libraries. The macro
+#   requires a preceding call to AX_BOOST_BASE. Further documentation is
+#   available at <http://randspringer.de/boost/index.html>.
 #
 #   This macro calls:
 #
-#     AC_SUBST(BOOST_SERIALIZATION_LIB)
 #     AC_SUBST(BOOST_SERIALIZATION_LIB)
 #
 #   And sets:
@@ -23,30 +22,30 @@
 #
 # LICENSE
 #
-#   Copyright (c) 2009 Thomas Porschberg <thomas@randspringer.de>
-#   Copyright (c) 2009 Michael Tindal
+#   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
-#   and this notice are preserved.
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 22
 
 AC_DEFUN([AX_BOOST_SERIALIZATION],
 [
 	AC_ARG_WITH([boost-serialization],
 	AS_HELP_STRING([--with-boost-serialization@<:@=special-lib@:>@],
                    [use the Serialization library from boost - it is possible to specify a certain library for the linker
-                        e.g. --with-boost-serialization=boost_serialization-gcc-mt ]),
+                        e.g. --with-boost-serialization=boost_serialization-gcc-mt-d-1_33_1 ]),
         [
         if test "$withval" = "no"; then
 			want_boost="no"
         elif test "$withval" = "yes"; then
             want_boost="yes"
             ax_boost_user_serialization_lib=""
-            ax_booth_user_serialization_lib=""
         else
 		    want_boost="yes"
-			echo "using $withval"
-        	ax_boost_user_serialization_lib="$withval"
+		ax_boost_user_serialization_lib="$withval"
 		fi
         ],
         [want_boost="yes"]
@@ -54,9 +53,9 @@ AC_DEFUN([AX_BOOST_SERIALIZATION],
 
 	if test "x$want_boost" = "xyes"; then
         AC_REQUIRE([AC_PROG_CC])
-        AC_REQUIRE([AC_CANONICAL_BUILD])
 		CPPFLAGS_SAVED="$CPPFLAGS"
 		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+	    AC_MSG_WARN(BOOST_CPPFLAGS $BOOST_CPPFLAGS)
 		export CPPFLAGS
 
 		LDFLAGS_SAVED="$LDFLAGS"
@@ -66,70 +65,53 @@ AC_DEFUN([AX_BOOST_SERIALIZATION],
         AC_CACHE_CHECK(whether the Boost::Serialization library is available,
 					   ax_cv_boost_serialization,
         [AC_LANG_PUSH([C++])
-			 CXXFLAGS_SAVE=$CXXFLAGS
-			 AC_COMPILE_IFELSE(AC_LANG_PROGRAM([[@%:@include <boost/serialization/utility.hpp>]]),
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <fstream>
+												 @%:@include <boost/archive/text_oarchive.hpp>
+                                                 @%:@include <boost/archive/text_iarchive.hpp>
+												]],
+                                   [[std::ofstream ofs("filename");
+									boost::archive::text_oarchive oa(ofs);
+									 return 0;
+                                   ]])],
                    ax_cv_boost_serialization=yes, ax_cv_boost_serialization=no)
-			 CXXFLAGS=$CXXFLAGS_SAVE
-             AC_LANG_POP([C++])
+         AC_LANG_POP([C++])
 		])
 		if test "x$ax_cv_boost_serialization" = "xyes"; then
-            AC_SUBST(BOOST_CPPFLAGS)
-
 			AC_DEFINE(HAVE_BOOST_SERIALIZATION,,[define if the Boost::Serialization library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
-
-			LDFLAGS_SAVE=$LDFLAGS
-
             if test "x$ax_boost_user_serialization_lib" = "x"; then
-                for libextension in `ls $BOOSTLIBDIR/libboost_serialization*.so* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_serialization.*\)\.so.*$;\1;'` `ls $BOOSTLIBDIR/libboost_serialization*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_serialization.*\)\.a*$;\1;'`; do
+                for libextension in `ls $BOOSTLIBDIR/libboost_serialization*.so* $BOOSTLIBDIR/libboost_serialization*.dylib* $BOOSTLIBDIR/libboost_serialization*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_serialization.*\)\.so.*$;\1;' -e 's;^lib\(boost_serialization.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_serialization.*\)\.a*$;\1;'` ; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
+				    AC_CHECK_LIB($ax_lib, main,
                                  [BOOST_SERIALIZATION_LIB="-l$ax_lib"; AC_SUBST(BOOST_SERIALIZATION_LIB) link_serialization="yes"; break],
                                  [link_serialization="no"])
-  				done
+				done
                 if test "x$link_serialization" != "xyes"; then
-                for libextension in `ls $BOOSTLIBDIR/boost_serialization*.dll* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_serialization.*\)\.dll.*$;\1;'` `ls $BOOSTLIBDIR/libboost_serialization*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_serialization.*\)\.a*$;\1;'` ; do
+                for libextension in `ls $BOOSTLIBDIR/boost_serialization*.dll* $BOOSTLIBDIR/boost_serialization*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_serialization.*\)\.dll.*$;\1;' -e 's;^\(boost_serialization.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
+				    AC_CHECK_LIB($ax_lib, main,
                                  [BOOST_SERIALIZATION_LIB="-l$ax_lib"; AC_SUBST(BOOST_SERIALIZATION_LIB) link_serialization="yes"; break],
                                  [link_serialization="no"])
-  				done
+				done
                 fi
 
             else
-                BOOST_SERIALIZATION_LIB="$ax_boost_user_serialization_lib"; 
-				AC_SUBST(BOOST_SERIALIZATION_LIB) 
-				link_serialization="yes";
-               
+               for ax_lib in $ax_boost_user_serialization_lib boost_serialization-$ax_boost_user_serialization_lib; do
+				      AC_CHECK_LIB($ax_lib, main,
+                                   [BOOST_SERIALIZATION_LIB="-l$ax_lib"; AC_SUBST(BOOST_SERIALIZATION_LIB) link_serialization="yes"; break],
+                                   [link_serialization="no"])
+                  done
 
             fi
-            
-            if test "x$ax_boost_user_serialization_lib" = "x"; then
-                for libextension in `ls $BOOSTLIBDIR/libboost_serialization*.so* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_serialization.*\)\.so.*$;\1;'` `ls $BOOSTLIBDIR/libboost_serialization*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_serialization.*\)\.a*$;\1;'`; do
-                     ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_SERIALIZATION_LIB="-l$ax_lib"; AC_SUBST(BOOST_SERIALIZATION_LIB) link_serialization="yes"; break],
-                                 [link_serialization="no"])
-  				done
-                if test "x$link_serialization" != "xyes"; then
-                for libextension in `ls $BOOSTLIBDIR/boost_serialization*.dll* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_serialization.*\)\.dll.*$;\1;'` `ls $BOOSTLIBDIR/libboost_serialization*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_serialization.*\)\.a*$;\1;'` ; do
-                     ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_SERIALIZATION_LIB="-l$ax_lib"; AC_SUBST(BOOST_SERIALIZATION_LIB) link_serialization="yes"; break],
-                                 [link_serialization="no"])
-  				done
-                fi
-
-            else
-                BOOST_SERIALIZATION_LIB="$ax_boost_user_serialization_lib"; 
-				AC_SUBST(BOOST_SERIALIZATION_LIB) 
-				link_serialization="yes";
-               
-
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
             fi
+			if test "x$link_serialization" != "xyes"; then
+				AC_MSG_ERROR(Could not link against $ax_lib !)
+			fi
 		fi
 
 		CPPFLAGS="$CPPFLAGS_SAVED"
-    	LDFLAGS="$LDFLAGS_SAVED"
+	LDFLAGS="$LDFLAGS_SAVED"
 	fi
 ])

--- a/ax_boost_system.m4
+++ b/ax_boost_system.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#            http://autoconf-archive.cryp.to/ax_boost_system.html
+#     https://www.gnu.org/software/autoconf-archive/ax_boost_system.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -15,7 +15,6 @@
 #   This macro calls:
 #
 #     AC_SUBST(BOOST_SYSTEM_LIB)
-#     AC_SUBST(BOOST_SYSTEM_LIB)
 #
 #   And sets:
 #
@@ -23,12 +22,16 @@
 #
 # LICENSE
 #
-#   Copyright (c) 2009 Thomas Porschberg <thomas@randspringer.de>
-#   Copyright (c) 2009 Michael Tindal
+#   Copyright (c) 2008 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2008 Michael Tindal
+#   Copyright (c) 2008 Daniel Casimiro <dan.casimiro@gmail.com>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
-#   and this notice are preserved.
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 19
 
 AC_DEFUN([AX_BOOST_SYSTEM],
 [
@@ -42,11 +45,9 @@ AC_DEFUN([AX_BOOST_SYSTEM],
         elif test "$withval" = "yes"; then
             want_boost="yes"
             ax_boost_user_system_lib=""
-            ax_booth_user_system_lib=""
         else
 		    want_boost="yes"
-			echo "using $withval"
-        	ax_boost_user_system_lib="$withval"
+		ax_boost_user_system_lib="$withval"
 		fi
         ],
         [want_boost="yes"]
@@ -67,69 +68,54 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 					   ax_cv_boost_system,
         [AC_LANG_PUSH([C++])
 			 CXXFLAGS_SAVE=$CXXFLAGS
-			 AC_COMPILE_IFELSE(AC_LANG_PROGRAM([[@%:@include <boost/system/system_error.hpp>]]),
+			 CXXFLAGS=
+
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/system/error_code.hpp>]],
+				    [[boost::system::error_category *a = 0;]])],
                    ax_cv_boost_system=yes, ax_cv_boost_system=no)
 			 CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])
 		])
 		if test "x$ax_cv_boost_system" = "xyes"; then
-            AC_SUBST(BOOST_CPPFLAGS)
+			AC_SUBST(BOOST_CPPFLAGS)
 
 			AC_DEFINE(HAVE_BOOST_SYSTEM,,[define if the Boost::System library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
 
 			LDFLAGS_SAVE=$LDFLAGS
-
             if test "x$ax_boost_user_system_lib" = "x"; then
-                for libextension in `ls $BOOSTLIBDIR/libboost_system*.so* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_system.*\)\.so.*$;\1;'` `ls $BOOSTLIBDIR/libboost_system*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_system.*\)\.a*$;\1;'`; do
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_system* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
+				    AC_CHECK_LIB($ax_lib, main,
                                  [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
                                  [link_system="no"])
-  				done
+				done
                 if test "x$link_system" != "xyes"; then
-                for libextension in `ls $BOOSTLIBDIR/boost_system*.dll* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_system.*\)\.dll.*$;\1;'` `ls $BOOSTLIBDIR/libboost_system*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_system.*\)\.a*$;\1;'` ; do
+                for libextension in `ls -r $BOOSTLIBDIR/boost_system* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
+				    AC_CHECK_LIB($ax_lib, main,
                                  [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
                                  [link_system="no"])
-  				done
+				done
                 fi
 
             else
-                BOOST_SYSTEM_LIB="$ax_boost_user_system_lib"; 
-				AC_SUBST(BOOST_SYSTEM_LIB) 
-				link_system="yes";
-               
+               for ax_lib in $ax_boost_user_system_lib boost_system-$ax_boost_user_system_lib; do
+				      AC_CHECK_LIB($ax_lib, main,
+                                   [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
+                                   [link_system="no"])
+                  done
 
             fi
-            
-            if test "x$ax_boost_user_system_lib" = "x"; then
-                for libextension in `ls $BOOSTLIBDIR/libboost_system*.so* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_system.*\)\.so.*$;\1;'` `ls $BOOSTLIBDIR/libboost_system*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_system.*\)\.a*$;\1;'`; do
-                     ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
-                                 [link_system="no"])
-  				done
-                if test "x$link_system" != "xyes"; then
-                for libextension in `ls $BOOSTLIBDIR/boost_system*.dll* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_system.*\)\.dll.*$;\1;'` `ls $BOOSTLIBDIR/libboost_system*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_system.*\)\.a*$;\1;'` ; do
-                     ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
-                                 [link_system="no"])
-  				done
-                fi
-
-            else
-                BOOST_SYSTEM_LIB="$ax_boost_user_system_lib"; 
-				AC_SUBST(BOOST_SYSTEM_LIB) 
-				link_system="yes";
-               
-
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
             fi
+			if test "x$link_system" = "xno"; then
+				AC_MSG_ERROR(Could not link against $ax_lib !)
+			fi
 		fi
 
 		CPPFLAGS="$CPPFLAGS_SAVED"
-    	LDFLAGS="$LDFLAGS_SAVED"
+	LDFLAGS="$LDFLAGS_SAVED"
 	fi
 ])

--- a/ax_boost_thread.m4
+++ b/ax_boost_thread.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#            http://autoconf-archive.cryp.to/ax_boost_thread.html
+#     https://www.gnu.org/software/autoconf-archive/ax_boost_thread.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -15,7 +15,6 @@
 #   This macro calls:
 #
 #     AC_SUBST(BOOST_THREAD_LIB)
-#     AC_SUBST(BOOST_SYSTEM_LIB)
 #
 #   And sets:
 #
@@ -28,142 +27,137 @@
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
-#   and this notice are preserved.
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 31
 
 AC_DEFUN([AX_BOOST_THREAD],
 [
-	AC_ARG_WITH([boost-thread],
-	AS_HELP_STRING([--with-boost-thread@<:@=special-lib@:>@],
-                   [use the Thread library from boost - it is possible to specify a certain library for the linker
-                        e.g. --with-boost-thread=boost_thread-gcc-mt ]),
+    AC_ARG_WITH([boost-thread],
+    AS_HELP_STRING([--with-boost-thread@<:@=special-lib@:>@],
+                   [use the Thread library from boost -
+                    it is possible to specify a certain library for the linker
+                    e.g. --with-boost-thread=boost_thread-gcc-mt ]),
         [
-        if test "$withval" = "no"; then
-			want_boost="no"
-        elif test "$withval" = "yes"; then
+        if test "$withval" = "yes"; then
             want_boost="yes"
             ax_boost_user_thread_lib=""
-            ax_booth_user_system_lib=""
         else
-		    want_boost="yes"
-			echo "using $withval"
-        	ax_boost_user_thread_lib="$withval"
-		fi
+            want_boost="yes"
+            ax_boost_user_thread_lib="$withval"
+        fi
         ],
         [want_boost="yes"]
-	)
+    )
 
-	if test "x$want_boost" = "xyes"; then
+    if test "x$want_boost" = "xyes"; then
         AC_REQUIRE([AC_PROG_CC])
         AC_REQUIRE([AC_CANONICAL_BUILD])
-		CPPFLAGS_SAVED="$CPPFLAGS"
-		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-		export CPPFLAGS
+        CPPFLAGS_SAVED="$CPPFLAGS"
+        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+        export CPPFLAGS
 
-		LDFLAGS_SAVED="$LDFLAGS"
-		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
-		export LDFLAGS
+        LDFLAGS_SAVED="$LDFLAGS"
+        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+        export LDFLAGS
 
         AC_CACHE_CHECK(whether the Boost::Thread library is available,
-					   ax_cv_boost_thread,
+                       ax_cv_boost_thread,
         [AC_LANG_PUSH([C++])
-			 CXXFLAGS_SAVE=$CXXFLAGS
+             CXXFLAGS_SAVE=$CXXFLAGS
 
-			 if test "x$build_os" = "xsolaris" ; then
-  				 CXXFLAGS="-pthreads $CXXFLAGS"
-			 elif test "x$build_os" = "xming32" ; then
-				 CXXFLAGS="-mthreads $CXXFLAGS"
-			 else
-				CXXFLAGS="-pthread $CXXFLAGS"
-			 fi
-			 AC_COMPILE_IFELSE(AC_LANG_PROGRAM([[@%:@include <boost/thread/thread.hpp>]],
-                                   [[boost::thread_group thrds;
-                                   return 0;]]),
-                   ax_cv_boost_thread=yes, ax_cv_boost_thread=no)
-			 CXXFLAGS=$CXXFLAGS_SAVE
+             if test "x$host_os" = "xsolaris" ; then
+                 CXXFLAGS="-pthreads $CXXFLAGS"
+             elif test "x$host_os" = "xmingw32" ; then
+                 CXXFLAGS="-mthreads $CXXFLAGS"
+             else
+                CXXFLAGS="-pthread $CXXFLAGS"
+             fi
+             AC_COMPILE_IFELSE([
+                 AC_LANG_PROGRAM(
+                     [[@%:@include <boost/thread/thread.hpp>]],
+                     [[boost::thread_group thrds;
+                       return 0;]])],
+                 ax_cv_boost_thread=yes, ax_cv_boost_thread=no)
+             CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])
-		])
-		if test "x$ax_cv_boost_thread" = "xyes"; then
-           if test "x$build_os" = "xsolaris" ; then
-			  BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
-		   elif test "x$build_os" = "xming32" ; then
-			  BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
-		   else
-			  BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
-		   fi
+        ])
+        if test "x$ax_cv_boost_thread" = "xyes"; then
+           if test "x$host_os" = "xsolaris" ; then
+              BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
+           elif test "x$host_os" = "xmingw32" ; then
+              BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
+           else
+              BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
+           fi
 
-			AC_SUBST(BOOST_CPPFLAGS)
+            AC_SUBST(BOOST_CPPFLAGS)
 
-			AC_DEFINE(HAVE_BOOST_THREAD,,[define if the Boost::Thread library is available])
+            AC_DEFINE(HAVE_BOOST_THREAD,,
+                      [define if the Boost::Thread library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
 
-			LDFLAGS_SAVE=$LDFLAGS
-                        case "x$build_os" in
+            LDFLAGS_SAVE=$LDFLAGS
+                        case "x$host_os" in
                           *bsd* )
                                LDFLAGS="-pthread $LDFLAGS"
                           break;
                           ;;
                         esac
             if test "x$ax_boost_user_thread_lib" = "x"; then
-                for libextension in `ls $BOOSTLIBDIR/libboost_thread*.so* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_thread.*\)\.so.*$;\1;'` `ls $BOOSTLIBDIR/libboost_thread*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_thread.*\)\.a*$;\1;'`; do
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_thread* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'`; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                    AC_CHECK_LIB($ax_lib, main,
+                                 [link_thread="yes"; break],
                                  [link_thread="no"])
-  				done
+                done
                 if test "x$link_thread" != "xyes"; then
-                for libextension in `ls $BOOSTLIBDIR/boost_thread*.dll* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_thread.*\)\.dll.*$;\1;'` `ls $BOOSTLIBDIR/libboost_thread*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_thread.*\)\.a*$;\1;'` ; do
+                for libextension in `ls -r $BOOSTLIBDIR/boost_thread* 2>/dev/null | sed 's,.*/,,' | sed 's,\..*,,'`; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                    AC_CHECK_LIB($ax_lib, main,
+                                 [link_thread="yes"; break],
                                  [link_thread="no"])
-  				done
+                done
                 fi
 
             else
-                BOOST_THREAD_LIB="$ax_boost_user_thread_lib"; 
-				AC_SUBST(BOOST_THREAD_LIB) 
-				link_thread="yes";
-               
+               for ax_lib in $ax_boost_user_thread_lib boost_thread-$ax_boost_user_thread_lib; do
+                      AC_CHECK_LIB($ax_lib, main,
+                                   [link_thread="yes"; break],
+                                   [link_thread="no"])
+                  done
 
             fi
-			if test "x$link_thread" = "xno"; then
-				AC_MSG_ERROR(Could not link against $ax_lib !)
-                        else
-                           case "x$build_os" in
-                              *bsd* )
-			        BOOST_LDFLAGS="-pthread $BOOST_LDFLAGS"
-                              break;
-                              ;;
-                           esac
-
-			fi
-            
-            if test "x$ax_boost_user_system_lib" = "x"; then
-                for libextension in `ls $BOOSTLIBDIR/libboost_system*.so* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_system.*\)\.so.*$;\1;'` `ls $BOOSTLIBDIR/libboost_system*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_system.*\)\.a*$;\1;'`; do
-                     ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
-                                 [link_system="no"])
-  				done
-                if test "x$link_system" != "xyes"; then
-                for libextension in `ls $BOOSTLIBDIR/boost_system*.dll* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_system.*\)\.dll.*$;\1;'` `ls $BOOSTLIBDIR/libboost_system*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^\(boost_system.*\)\.a*$;\1;'` ; do
-                     ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
-                                 [link_system="no"])
-  				done
-                fi
-
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+            if test "x$link_thread" = "xno"; then
+                AC_MSG_ERROR(Could not link against $ax_lib !)
             else
-                BOOST_SYSTEM_LIB="$ax_boost_user_system_lib"; 
-				AC_SUBST(BOOST_SYSTEM_LIB) 
-				link_system="yes";
-               
-
+                BOOST_THREAD_LIB="-l$ax_lib"
+                case "x$host_os" in
+                    *bsd* )
+                        BOOST_LDFLAGS="-pthread $BOOST_LDFLAGS"
+                        break;
+                        ;;
+                    xsolaris )
+                        BOOST_THREAD_LIB="$BOOST_THREAD_LIB -lpthread"
+                        break;
+                        ;;
+                    xmingw32 )
+                        break;
+                        ;;
+                    * )
+                        BOOST_THREAD_LIB="$BOOST_THREAD_LIB -lpthread"
+                        break;
+                        ;;
+                esac
+                AC_SUBST(BOOST_THREAD_LIB)
             fi
-		fi
+        fi
 
-		CPPFLAGS="$CPPFLAGS_SAVED"
-    	LDFLAGS="$LDFLAGS_SAVED"
-	fi
+        CPPFLAGS="$CPPFLAGS_SAVED"
+        LDFLAGS="$LDFLAGS_SAVED"
+    fi
 ])

--- a/ax_check_eigen.m4
+++ b/ax_check_eigen.m4
@@ -53,10 +53,13 @@ if test "$ac_eigen_path" != ""; then
 EIGEN_CPPFLAGS="-I$ac_eigen_path/include"
 else
 for ac_eigen_path_tmp in /usr /usr/local /opt /opt/local ; do
-if test -d "$ac_eigen_path_tmp/include/eigen" && test -r "$ac_eigen_path_tmp/include/eigen"; then
-EIGEN_CPPFLAGS="-I$ac_eigen_path_tmp/include"
-break;
-fi
+  for ac_eigen_subdir in eigen eigen3 ; do
+    ac_candidate_path="$ac_eigen_path_tmp/include/$ac_eigen_subdir"
+    if test -d "$ac_candidate_path" && test -r "$ac_candidate_path"; then
+      EIGEN_CPPFLAGS="-I$ac_candidate_path"
+      break;
+    fi
+  done
 done
 fi
 
@@ -73,6 +76,7 @@ AC_MSG_RESULT(yes)
 succeeded=yes
 found_system=yes
 ],[
+AC_MSG_ERROR([[We could not detect the Eigen3 library. Try installing libeigen3, or specifying a path with --with-eigen=/some/path]])
 ])
 AC_LANG_POP([C++])
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,7 @@ m4_include([ax_boost_system.m4])
 m4_include([ax_boost_serialization.m4])
 m4_include([ax_boost_filesystem.m4])
 m4_include([ax_bam.m4])
+m4_include([ax_check_eigen.m4])
 m4_include([ax_check_zlib.m4])
 
 define([svnversion], esyscmd([sh -c "svnversion|tr -d '\n'"]))dnl
@@ -111,7 +112,7 @@ AC_ARG_ENABLE(profiling,      [  --enable-profiling        enable profiling with
 	  
 CFLAGS="${generic_CFLAGS} ${ext_CFLAGS} ${user_CFLAGS} ${debug_CFLAGS} ${OPENMP_CFLAGS}"
 CXXFLAGS="$CFLAGS"
-CXXFLAGS="${CXXFLAGS} ${BOOST_CPPFLAGS} ${BAM_CPPFLAGS} ${EIGEN3_CPPFLAGS}"
+CXXFLAGS="${CXXFLAGS} ${BOOST_CPPFLAGS} ${BAM_CPPFLAGS} ${EIGEN_CPPFLAGS}"
 user_LDFLAGS="$LDFLAGS"
 LDFLAGS="${ext_LDFLAGS} ${user_LDFLAGS}"
 

--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,7 @@ AC_ARG_ENABLE(profiling,      [  --enable-profiling        enable profiling with
 	  [ext_LDFLAGS="-lprofiler -ltcmalloc"], [])
 	  
 CFLAGS="${generic_CFLAGS} ${ext_CFLAGS} ${user_CFLAGS} ${debug_CFLAGS} ${OPENMP_CFLAGS}"
-CXXFLAGS="$CFLAGS"
+CXXFLAGS="$CFLAGS -std=c++03"
 CXXFLAGS="${CXXFLAGS} ${BOOST_CPPFLAGS} ${BAM_CPPFLAGS} ${EIGEN_CPPFLAGS}"
 user_LDFLAGS="$LDFLAGS"
 LDFLAGS="${ext_LDFLAGS} ${user_LDFLAGS}"

--- a/src/abundances.cpp
+++ b/src/abundances.cpp
@@ -4851,7 +4851,7 @@ void merge_precomputed_expression_worker(const string& locus_tag,
     for (size_t i = 0; i < expression_factories.size(); ++i)
     {
         boost::shared_ptr<PrecomputedExpressionBundleFactory> pBundleFac = expression_factories[i];
-        boost::shared_ptr<const PrecomputedExpressionHitFactory> pHitFac = dynamic_pointer_cast<const PrecomputedExpressionHitFactory> (pBundleFac->hit_factory());
+        boost::shared_ptr<const PrecomputedExpressionHitFactory> pHitFac = boost::dynamic_pointer_cast<const PrecomputedExpressionHitFactory> (pBundleFac->hit_factory());
         assert (pHitFac);
         
         boost::shared_ptr<const ReadGroupProperties> rg_prop = pBundleFac->read_group_properties();

--- a/src/biascorrection.h
+++ b/src/biascorrection.h
@@ -15,7 +15,7 @@
 #include <vector>
 #include <list>
 #include <string>
-#include <boost/tr1/unordered_map.hpp>
+#include <boost/unordered_map.hpp>
 #include <boost/thread.hpp>
 #include "common.h"
 

--- a/src/clustering.h
+++ b/src/clustering.h
@@ -37,9 +37,7 @@
 
 #include "abundances.h"
 
-using namespace boost;
-
-typedef adjacency_list <vecS, vecS, undirectedS> AbundanceGraph;
+typedef boost::adjacency_list <boost::vecS, boost::vecS, boost::undirectedS> AbundanceGraph;
 
 struct ConnectByExonOverlap
 {
@@ -83,7 +81,7 @@ void cluster_transcripts(const AbundanceGroup& transfrags,
                          ublas::matrix<double>* new_count = NULL,
                          ublas::matrix<double>* new_fpkm = NULL)
 {
-	adjacency_list <vecS, vecS, undirectedS> G;
+	boost::adjacency_list <boost::vecS, boost::vecS, boost::undirectedS> G;
 	
 	transfrags_by_cluster.clear();
 	

--- a/src/cufflinks.cpp
+++ b/src/cufflinks.cpp
@@ -1519,7 +1519,7 @@ bool assemble_hits(BundleFactory& bundle_factory, boost::shared_ptr<BiasLearner>
 		curr_threads++;
 		thread_pool_lock.unlock();
 		
-		thread asmbl(assemble_bundle,
+		boost::thread asmbl(assemble_bundle,
 					 boost::cref(rt), 
 					 bundle_ptr,
                      bundle_factory.read_group_properties(),

--- a/src/differential.cpp
+++ b/src/differential.cpp
@@ -940,7 +940,7 @@ void sample_worker(bool non_empty,
     for (size_t i = 0; i < factories.size(); ++i)
     {
         boost::shared_ptr<BundleFactory> pFac = factories[i];
-        boost::shared_ptr<PrecomputedExpressionBundleFactory> pBundleFac = dynamic_pointer_cast<PrecomputedExpressionBundleFactory> (pFac);
+        boost::shared_ptr<PrecomputedExpressionBundleFactory> pBundleFac = boost::dynamic_pointer_cast<PrecomputedExpressionBundleFactory> (pFac);
         if (pBundleFac)
         {
             // If we get here, this factory refers to a pre computed expression object.

--- a/src/transitive_closure.h
+++ b/src/transitive_closure.h
@@ -34,8 +34,6 @@
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/graph/named_function_params.hpp>
 	
-using namespace boost;
-
 typedef uint16_t v_id_size_type;
 
 inline void
@@ -79,26 +77,26 @@ void transitive_closure(const Graph & g, GraphTC & tc,
 						G_to_TC_VertexMap g_to_tc_map,
 						VertexIndexMap index_map)
 {
-    if (num_vertices(g) == 0)
+    if (boost::num_vertices(g) == 0)
 		return;
-    typedef typename graph_traits < Graph >::vertex_descriptor vertex;
-    typedef typename graph_traits < Graph >::edge_descriptor edge;
-    typedef typename graph_traits < Graph >::vertex_iterator vertex_iterator;
+    typedef typename boost::graph_traits < Graph >::vertex_descriptor vertex;
+    typedef typename boost::graph_traits < Graph >::edge_descriptor edge;
+    typedef typename boost::graph_traits < Graph >::vertex_iterator vertex_iterator;
     //typedef typename property_traits < VertexIndexMap >::value_type size_type;
 
-    typedef typename graph_traits <
+    typedef typename boost::graph_traits <
 	Graph >::adjacency_iterator adjacency_iterator;
 	
-    function_requires < VertexListGraphConcept < Graph > >();
-    function_requires < AdjacencyGraphConcept < Graph > >();
-    function_requires < VertexMutableGraphConcept < GraphTC > >();
-    function_requires < EdgeMutableGraphConcept < GraphTC > >();
-    function_requires < ReadablePropertyMapConcept < VertexIndexMap,
+    boost::function_requires < boost::VertexListGraphConcept < Graph > >();
+    boost::function_requires < boost::AdjacencyGraphConcept < Graph > >();
+    boost::function_requires < boost::VertexMutableGraphConcept < GraphTC > >();
+    boost::function_requires < boost::EdgeMutableGraphConcept < GraphTC > >();
+    boost::function_requires < boost::ReadablePropertyMapConcept < VertexIndexMap,
 	vertex > >();
 	
     typedef v_id_size_type cg_vertex;
-    std::vector < cg_vertex > component_number_vec(num_vertices(g));
-    iterator_property_map < cg_vertex *, VertexIndexMap, cg_vertex, cg_vertex& >
+    std::vector < cg_vertex > component_number_vec(boost::num_vertices(g));
+    boost::iterator_property_map < cg_vertex *, VertexIndexMap, cg_vertex, cg_vertex& >
 	component_number(&component_number_vec[0], index_map);
 	
     //int num_scc = strong_components(g, component_number,
@@ -106,16 +104,16 @@ void transitive_closure(const Graph & g, GraphTC & tc,
 	
 	size_t cn = 0;
 	vertex_iterator cu, cu_end;
-	for (tie(cu, cu_end) = vertices(g); cu != cu_end; ++cu) {
+	for (boost::tie(cu, cu_end) = vertices(g); cu != cu_end; ++cu) {
 		component_number[*cu] = cn++;
 		//fprintf(stderr, "%d\n", component_number[*cu]);
 	}
 	
     std::vector < std::vector < vertex > >components;
-    build_component_lists(g, num_vertices(g), component_number, components);
+    build_component_lists(g, boost::num_vertices(g), component_number, components);
 	
     typedef std::vector<std::vector<cg_vertex> > CG_t;
-    CG_t CG(num_vertices(g));
+    CG_t CG(boost::num_vertices(g));
 
 	for (cg_vertex s = 0; s < components.size(); ++s) {
 		std::vector < cg_vertex > adj;
@@ -123,7 +121,7 @@ void transitive_closure(const Graph & g, GraphTC & tc,
 		vertex u = components[s][0];
 
 		adjacency_iterator v, v_end;
-		for (tie(v, v_end) = adjacent_vertices(u, g); v != v_end; ++v) {
+		for (boost::tie(v, v_end) = boost::adjacent_vertices(u, g); v != v_end; ++v) {
 			cg_vertex t = component_number[*v];
 			if (s != t)           // Avoid loops in the condensation graph
 				adj.push_back(t);
@@ -138,16 +136,16 @@ void transitive_closure(const Graph & g, GraphTC & tc,
     }
 	
     std::vector<cg_vertex> topo_order;
-    std::vector<cg_vertex> topo_number(num_vertices(CG));
+    std::vector<cg_vertex> topo_number(boost::num_vertices(CG));
     topological_sort(CG, std::back_inserter(topo_order),
-                     vertex_index_map(identity_property_map()));
+                     vertex_index_map(boost::identity_property_map()));
     std::reverse(topo_order.begin(), topo_order.end());
     v_id_size_type n = 0;
     for (typename std::vector<cg_vertex>::iterator iter = topo_order.begin();
          iter != topo_order.end(); ++iter)
 		topo_number[*iter] = n++;
 	
-    for (size_t i = 0; i < num_vertices(CG); ++i)
+    for (size_t i = 0; i < boost::num_vertices(CG); ++i)
 		std::sort(CG[i].begin(), CG[i].end(),
 				  boost::bind(std::less<cg_vertex>(),
 							  boost::bind(subscript(topo_number), _1),
@@ -155,7 +153,7 @@ void transitive_closure(const Graph & g, GraphTC & tc,
 	
     std::vector<std::vector<cg_vertex> > chains;
     {
-		std::vector<cg_vertex> in_a_chain(num_vertices(CG));
+		std::vector<cg_vertex> in_a_chain(boost::num_vertices(CG));
 		for (typename std::vector<cg_vertex>::iterator i = topo_order.begin();
 			 i != topo_order.end(); ++i) {
 			cg_vertex v = *i;
@@ -165,9 +163,9 @@ void transitive_closure(const Graph & g, GraphTC & tc,
 				for (;;) {
 					chain.push_back(v);
 					in_a_chain[v] = true;
-					typename graph_traits<CG_t>::adjacency_iterator adj_first, adj_last;
-					tie(adj_first, adj_last) = adjacent_vertices(v, CG);
-					typename graph_traits<CG_t>::adjacency_iterator next
+					typename boost::graph_traits<CG_t>::adjacency_iterator adj_first, adj_last;
+					boost::tie(adj_first, adj_last) = boost::adjacent_vertices(v, CG);
+					typename boost::graph_traits<CG_t>::adjacency_iterator next
 					= std::find_if(adj_first, adj_last,
 								   std::not1(subscript(in_a_chain)));
 					if (next != adj_last)
@@ -179,8 +177,8 @@ void transitive_closure(const Graph & g, GraphTC & tc,
 			}
 		}
     }
-    std::vector<v_id_size_type> chain_number(num_vertices(CG));
-    std::vector<v_id_size_type> pos_in_chain(num_vertices(CG));
+    std::vector<v_id_size_type> chain_number(boost::num_vertices(CG));
+    std::vector<v_id_size_type> pos_in_chain(boost::num_vertices(CG));
     for (size_t i = 0; i < chains.size(); ++i)
 		for (size_t j = 0; j < chains[i].size(); ++j) {
 			cg_vertex v = chains[i][j];
@@ -189,14 +187,14 @@ void transitive_closure(const Graph & g, GraphTC & tc,
 		}
 	
     cg_vertex inf = (std::numeric_limits< cg_vertex >::max)();
-    std::vector<std::vector<cg_vertex> > successors(num_vertices(CG),
+    std::vector<std::vector<cg_vertex> > successors(boost::num_vertices(CG),
                                                     std::vector<cg_vertex>
                                                     (chains.size(), inf));
     for (typename std::vector<cg_vertex>::reverse_iterator
 		 i = topo_order.rbegin(); i != topo_order.rend(); ++i) {
 		cg_vertex u = *i;
-		typename graph_traits<CG_t>::adjacency_iterator adj, adj_last;
-		for (tie(adj, adj_last) = adjacent_vertices(u, CG);
+		typename boost::graph_traits<CG_t>::adjacency_iterator adj, adj_last;
+		for (boost::tie(adj, adj_last) = boost::adjacent_vertices(u, CG);
 			 adj != adj_last; ++adj) {
 			cg_vertex v = *adj;
 			if (topo_number[v] < successors[u][chain_number[v]]) {
@@ -223,18 +221,18 @@ void transitive_closure(const Graph & g, GraphTC & tc,
 	
 	
     // Add vertices to the transitive closure graph
-    typedef typename graph_traits < GraphTC >::vertex_descriptor tc_vertex;
+    typedef typename boost::graph_traits < GraphTC >::vertex_descriptor tc_vertex;
     {
 		vertex_iterator i, i_end;
-		for (tie(i, i_end) = boost::vertices(g); i != i_end; ++i)
+		for (boost::tie(i, i_end) = boost::vertices(g); i != i_end; ++i)
 			g_to_tc_map[*i] = add_vertex(tc);
     }
     // Add edges between all the vertices in two adjacent SCCs
-    typename graph_traits<CG_t>::vertex_iterator si, si_end;
-    for (tie(si, si_end) = boost::vertices(CG); si != si_end; ++si) {
+    typename boost::graph_traits<CG_t>::vertex_iterator si, si_end;
+    for (boost::tie(si, si_end) = boost::vertices(CG); si != si_end; ++si) {
 		cg_vertex s = *si;
-		typename graph_traits<CG_t>::adjacency_iterator i, i_end;
-		for (tie(i, i_end) = adjacent_vertices(s, CG); i != i_end; ++i) {
+		typename boost::graph_traits<CG_t>::adjacency_iterator i, i_end;
+		for (boost::tie(i, i_end) = boost::adjacent_vertices(s, CG); i != i_end; ++i) {
 			cg_vertex t = *i;
 			for (size_t k = 0; k < components[s].size(); ++k)
 				for (size_t l = 0; l < components[t].size(); ++l)
@@ -255,10 +253,10 @@ void transitive_closure(const Graph & g, GraphTC & tc,
     // Need to add it to transitive closure.
     {
 		vertex_iterator i, i_end;
-		for (tie(i, i_end) = vertices(g); i != i_end; ++i)
+		for (boost::tie(i, i_end) = vertices(g); i != i_end; ++i)
         {
 			adjacency_iterator ab, ae;
-			for (boost::tie(ab, ae) = adjacent_vertices(*i, g); ab != ae; ++ab)
+			for (boost::tie(ab, ae) = boost::adjacent_vertices(*i, g); ab != ae; ++ab)
             {
 				if (*ab == *i)
 					if (components[component_number[*i]].size() == 1)
@@ -271,15 +269,15 @@ void transitive_closure(const Graph & g, GraphTC & tc,
 template <typename Graph, typename GraphTC>
 void transitive_closure(const Graph & g, GraphTC & tc)
 {
-    if (num_vertices(g) == 0)
+    if (boost::num_vertices(g) == 0)
 		return;
-    typedef typename property_map<Graph, vertex_index_t>::const_type
+    typedef typename boost::property_map<Graph, boost::vertex_index_t>::const_type
 	VertexIndexMap;
-    VertexIndexMap index_map = get(vertex_index, g);
+    VertexIndexMap index_map = get(boost::vertex_index, g);
 	
-    typedef typename graph_traits<GraphTC>::vertex_descriptor tc_vertex;
-    std::vector<tc_vertex> to_tc_vec(num_vertices(g));
-    iterator_property_map < tc_vertex *, VertexIndexMap, tc_vertex, tc_vertex&>
+    typedef typename boost::graph_traits<GraphTC>::vertex_descriptor tc_vertex;
+    std::vector<tc_vertex> to_tc_vec(boost::num_vertices(g));
+    boost::iterator_property_map < tc_vertex *, VertexIndexMap, tc_vertex, tc_vertex&>
 	g_to_tc_map(&to_tc_vec[0], index_map);
 	
     transitive_closure(g, tc, g_to_tc_map, index_map);
@@ -292,9 +290,9 @@ void transitive_closure_dispatch
 (const Graph & g, GraphTC & tc,
  G_to_TC_VertexMap g_to_tc_map, VertexIndexMap index_map)
 {
-	typedef typename graph_traits < GraphTC >::vertex_descriptor tc_vertex;
+	typedef typename boost::graph_traits < GraphTC >::vertex_descriptor tc_vertex;
 	typename std::vector < tc_vertex >::size_type
-	n = is_default_param(g_to_tc_map) ? num_vertices(g) : 1;
+	n = is_default_param(g_to_tc_map) ? boost::num_vertices(g) : 1;
 	std::vector < tc_vertex > to_tc_vec(n);
 	
 	transitive_closure
@@ -308,23 +306,23 @@ void transitive_closure_dispatch
 template < typename Graph, typename GraphTC,
 typename P, typename T, typename R >
 void transitive_closure(const Graph & g, GraphTC & tc,
-						const bgl_named_params < P, T, R > &params)
+						const boost::bgl_named_params < P, T, R > &params)
 {
-    if (num_vertices(g) == 0)
+    if (boost::num_vertices(g) == 0)
 		return;
     transitive_closure_dispatch
-	(g, tc, get_param(params, orig_to_copy_t()),
-	 choose_const_pmap(get_param(params, vertex_index), g, vertex_index) );
+	(g, tc, get_param(params, boost::orig_to_copy_t()),
+	 choose_const_pmap(get_param(params, boost::vertex_index), g, boost::vertex_index) );
 }
 
 
 template < typename G > void warshall_transitive_closure(G & g)
 {
-    typedef typename graph_traits < G >::vertex_descriptor vertex;
-    typedef typename graph_traits < G >::vertex_iterator vertex_iterator;
+    typedef typename boost::graph_traits < G >::vertex_descriptor vertex;
+    typedef typename boost::graph_traits < G >::vertex_iterator vertex_iterator;
 	
-    function_requires < AdjacencyMatrixConcept < G > >();
-    function_requires < EdgeMutableGraphConcept < G > >();
+    boost::function_requires < boost::AdjacencyMatrixConcept < G > >();
+    boost::function_requires < boost::EdgeMutableGraphConcept < G > >();
 	
     // Matrix form:
     // for k
@@ -333,10 +331,10 @@ template < typename G > void warshall_transitive_closure(G & g)
     //      for j
     //        A[i,j] = A[i,j] | A[k,j]
     vertex_iterator ki, ke, ii, ie, ji, je;
-    for (tie(ki, ke) = vertices(g); ki != ke; ++ki)
-		for (tie(ii, ie) = vertices(g); ii != ie; ++ii)
+    for (boost::tie(ki, ke) = vertices(g); ki != ke; ++ki)
+		for (boost::tie(ii, ie) = vertices(g); ii != ie; ++ii)
 			if (edge(*ii, *ki, g).second)
-				for (tie(ji, je) = vertices(g); ji != je; ++ji)
+				for (boost::tie(ji, je) = vertices(g); ji != je; ++ji)
 					if (!edge(*ii, *ji, g).second && edge(*ki, *ji, g).second) {
 						add_edge(*ii, *ji, g);
 					}
@@ -346,14 +344,14 @@ template < typename G > void warshall_transitive_closure(G & g)
 template < typename G > void warren_transitive_closure(G & g)
 {
     using namespace boost;
-    typedef typename graph_traits < G >::vertex_descriptor vertex;
-    typedef typename graph_traits < G >::vertex_iterator vertex_iterator;
+    typedef typename boost::graph_traits < G >::vertex_descriptor vertex;
+    typedef typename boost::graph_traits < G >::vertex_iterator vertex_iterator;
 	
     function_requires < AdjacencyMatrixConcept < G > >();
     function_requires < EdgeMutableGraphConcept < G > >();
 	
     // Make sure second loop will work
-    if (num_vertices(g) == 0)
+    if (boost::num_vertices(g) == 0)
 		return;
 	
     // for i = 2 to n
@@ -363,10 +361,10 @@ template < typename G > void warren_transitive_closure(G & g)
     //          A[i,j] = A[i,j] | A[k,j]
 	
     vertex_iterator ic, ie, jc, je, kc, ke;
-    for (tie(ic, ie) = vertices(g), ++ic; ic != ie; ++ic)
-		for (tie(kc, ke) = vertices(g); *kc != *ic; ++kc)
+    for (boost::tie(ic, ie) = vertices(g), ++ic; ic != ie; ++ic)
+		for (boost::tie(kc, ke) = vertices(g); *kc != *ic; ++kc)
 			if (edge(*ic, *kc, g).second)
-				for (tie(jc, je) = vertices(g); jc != je; ++jc)
+				for (boost::tie(jc, je) = vertices(g); jc != je; ++jc)
 					if (!edge(*ic, *jc, g).second && edge(*kc, *jc, g).second) {
 						add_edge(*ic, *jc, g);
 					}
@@ -376,10 +374,10 @@ template < typename G > void warren_transitive_closure(G & g)
     //        for j = 1 to n
     //          A[i,j] = A[i,j] | A[k,j]
 	
-    for (tie(ic, ie) = vertices(g), --ie; ic != ie; ++ic)
+    for (boost::tie(ic, ie) = vertices(g), --ie; ic != ie; ++ic)
 		for (kc = ic, ke = ie, ++kc; kc != ke; ++kc)
 			if (edge(*ic, *kc, g).second)
-				for (tie(jc, je) = vertices(g); jc != je; ++jc)
+				for (boost::tie(jc, je) = vertices(g); jc != je; ++jc)
 					if (!edge(*ic, *jc, g).second && edge(*kc, *jc, g).second) {
 						add_edge(*ic, *jc, g);
 					}


### PR DESCRIPTION
* Find Boost when installed in an architecture-specific directory (e.g. `/usr/lib/x86_64-linux-gnu`), achieved by updating to (slightly tweaked) latest versions of ax_boost_* from the autoconf extensions repository (https://www.gnu.org/software/autoconf-archive)
* Find Eigen3, including when it is installed to /usr/include/eigen3
* Use C++03 standard explicitly (g++-8 defaults to c++14, but Cufflinks doesn't compile with modern standards due to name clashes)
* Use boost::unordered, not boost::tr1, which has been removed as of recent releases of Boost.